### PR TITLE
Updated config.json for Fargate resources

### DIFF
--- a/terraform/job_config.json
+++ b/terraform/job_config.json
@@ -1,164 +1,164 @@
 {
     "downloader_aqua_quicklook" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_A", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_aqua_refined" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_A", "/data/output", "2000", "1", "no", "yes"]
     },
     "combiner_aqua_quicklook" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
-        "command": [ "300", "300", "yes", "MODIS_A", "QUICKLOOK", "-235", "input_list" ]
+        "command": [ "300", "0", "yes", "MODIS_A", "QUICKLOOK", "-235", "input_list" ]
     },
     "combiner_aqua_refined" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
         "command": [ "300", "0", "yes", "MODIS_A", "REFINED", "-235", "input_list" ]
     },
     "processor_aqua_quicklook" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
         "command": [ "300", "yes", "MODIS_A", "QUICKLOOK", "no", "-235", "input_list" ]
     },
     "processor_aqua_refined" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
         "command": [ "300", "yes", "MODIS_A", "REFINED", "no", "-235", "input_list" ]
     },
     "uploader_aqua_quicklook" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "aqua", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "aqua", "ops", "false" ]
     },
     "uploader_aqua_refined" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "aqua", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "aqua", "ops", "false" ]
     },
     "license_returner_aqua" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateaqualicense",
         "command": [ "unique_id", "prefix", "aqua", "ptype" ]
     },
     "downloader_terra_quicklook" : {
         "queue": "generate-terra",
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_T", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_terra_refined" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_T", "/data/output", "2000", "1", "no", "yes"]
     },
     "combiner_terra_quicklook" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
         "command": [ "300", "300", "yes", "MODIS_T", "QUICKLOOK", "-235", "input_list" ]
     },
     "combiner_terra_refined" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
         "command": [ "300", "0", "yes", "MODIS_T", "REFINED", "-235", "input_list" ]
     },
     "processor_terra_quicklook" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
         "command": [ "300", "yes", "MODIS_T", "QUICKLOOK", "no", "-235", "input_list" ]
     },
     "processor_terra_refined" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
         "command": [ "300", "yes", "MODIS_T", "REFINED", "no", "-235", "input_list" ]
     },
     "uploader_terra_quicklook" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "terra", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "terra", "ops", "false" ]
     },
     "uploader_terra_refined" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "terra", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "terra", "ops", "false" ]
     },
     "license_returner_terra" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateterralicense",
         "command": [ "unique_id", "prefix", "terra", "ptype" ]
     },
     "downloader_viirs_quicklook" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_viirs_refined" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
     },
     "combiner_viirs_quicklook" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
         "command": [ "300", "300", "yes", "VIIRS", "QUICKLOOK", "-235", "input_list" ]
     },
     "combiner_viirs_refined" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
         "command": [ "300", "0", "yes", "VIIRS", "REFINED", "-235", "input_list" ]
     },
     "processor_viirs_quicklook" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
         "command": [ "300", "yes", "VIIRS", "QUICKLOOK", "no", "-235", "input_list" ]
     },
     "processor_viirs_refined" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
         "command": [ "300", "yes", "VIIRS", "REFINED", "no", "-235", "input_list" ]
     },
     "uploader_viirs_quicklook" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "viirs", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "viirs", "ops", "false" ]
     },
     "uploader_viirs_refined" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "viirs", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "viirs", "ops", "false" ]
     },
     "license_returner_viirs" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateviirslicense",
         "command": [ "unique_id", "prefix", "viirs", "ptype" ]
     },
@@ -217,20 +217,20 @@
         "command": [ "unique_id", "prefix", "jpss1", "ptype" ]
     },
     "downloader_aqua_unmatched" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_A", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_terra_unmatched" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_T", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_viirs_unmatched" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
     },

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ data "aws_kms_key" "aws_s3" {
 }
 
 data "aws_s3_bucket" "s3_download_lists" {
-  bucket = "${var.prefix}"
+  bucket = var.prefix
 }
 
 data "aws_security_groups" "vpc_default_sg" {

--- a/terraform/partition_submit-lambda.tf
+++ b/terraform/partition_submit-lambda.tf
@@ -19,6 +19,11 @@ resource "aws_lambda_function" "aws_lambda_partition_submit" {
   }
 }
 
+resource "aws_lambda_function_event_invoke_config" "partition_submit_lambda_config" {
+  function_name          = aws_lambda_function.aws_lambda_partition_submit.function_name
+  maximum_retry_attempts = 0
+}
+
 # Upload job configuration file to S3 bucket
 resource "aws_s3_object" "aws_s3_bucket_job_configuration" {
   bucket                 = data.aws_s3_bucket.s3_download_lists.id

--- a/terraform/partition_submit-lambda.tf
+++ b/terraform/partition_submit-lambda.tf
@@ -25,6 +25,7 @@ resource "aws_s3_object" "aws_s3_bucket_job_configuration" {
   key                    = "config/job_config.json"
   server_side_encryption = "aws:kms"
   source                 = "job_config.json"
+  source_hash            = filemd5("job_config.json")
 }
 
 # Lambda resource-based policy


### PR DESCRIPTION
## Overview
- Updated job resources for Fargate instead of EC2.
- Added source hash in terraform file so it can detect changes to the job config json file.

For issue [PODAAC-6941](https://jira.jpl.nasa.gov/browse/PODAAC-6941)