### PR TITLE
Release/0.1.7

### DIFF
--- a/partition_submit/partition.py
+++ b/partition_submit/partition.py
@@ -61,7 +61,8 @@ class Partition:
     DOWNLOADS = {
         "aqua": {"filename" : "AQUA_MODIS", "quicklook": "MODIS_AQUA_L2_SST_OBPG_QUICKLOOK", "refined": "MODIS_AQUA_L2_SST_OBPG_REFINED"},
         "terra": {"filename" : "TERRA_MODIS", "quicklook": "MODIS_TERRA_L2_SST_OBPG_QUICKLOOK", "refined": "MODIS_TERRA_L2_SST_OBPG_REFINED"},
-        "viirs": {"filename" : "SNPP_VIIRS", "quicklook": "VIIRS_L2_SST_OBPG_QUICKLOOK", "refined": "VIIRS_L2_SST_OBPG_REFINED"}
+        "viirs": {"filename" : "SNPP_VIIRS", "quicklook": "VIIRS_L2_SST_OBPG_QUICKLOOK", "refined": "VIIRS_L2_SST_OBPG_REFINED"},
+        "jpss1": {"filename" : "JPSS1_VIIRS", "quicklook": "JPSS1_L2_SST_OBPG_QUICKLOOK", "refined": "JPSS1_L2_SST_OBPG_REFINED"}
     }
     
     def __init__(self, dataset, dlc_lists, out_dir, downloads_dir, jobs_dir,

--- a/partition_submit/partition_and_submit.py
+++ b/partition_submit/partition_and_submit.py
@@ -401,6 +401,8 @@ def event_handler(event, context):
             ds = "MODIS Aqua"
         elif dataset == "terra":
             ds = "MODIS Terra"
+        elif dataset == "jpss1":
+            ds = "JPSS1"
         else:
             ds = "VIIRS"
         logger.info(f"Dataset: {ds}")

--- a/terraform/job_config.json
+++ b/terraform/job_config.json
@@ -1,164 +1,164 @@
 {
     "downloader_aqua_quicklook" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_A", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_aqua_refined" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_A", "/data/output", "2000", "1", "no", "yes"]
     },
     "combiner_aqua_quicklook" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
-        "command": [ "300", "300", "yes", "MODIS_A", "QUICKLOOK", "-235", "input_list" ]
+        "command": [ "300", "0", "yes", "MODIS_A", "QUICKLOOK", "-235", "input_list" ]
     },
     "combiner_aqua_refined" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
         "command": [ "300", "0", "yes", "MODIS_A", "REFINED", "-235", "input_list" ]
     },
     "processor_aqua_quicklook" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
         "command": [ "300", "yes", "MODIS_A", "QUICKLOOK", "no", "-235", "input_list" ]
     },
     "processor_aqua_refined" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
         "command": [ "300", "yes", "MODIS_A", "REFINED", "no", "-235", "input_list" ]
     },
     "uploader_aqua_quicklook" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateaquaquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "aqua", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "aqua", "ops", "false" ]
     },
     "uploader_aqua_refined" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateaquarefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "aqua", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "aqua", "ops", "false" ]
     },
     "license_returner_aqua" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateaqualicense",
         "command": [ "unique_id", "prefix", "aqua", "ptype" ]
     },
     "downloader_terra_quicklook" : {
         "queue": "generate-terra",
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_T", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_terra_refined" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_T", "/data/output", "2000", "1", "no", "yes"]
     },
     "combiner_terra_quicklook" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
         "command": [ "300", "300", "yes", "MODIS_T", "QUICKLOOK", "-235", "input_list" ]
     },
     "combiner_terra_refined" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
         "command": [ "300", "0", "yes", "MODIS_T", "REFINED", "-235", "input_list" ]
     },
     "processor_terra_quicklook" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
         "command": [ "300", "yes", "MODIS_T", "QUICKLOOK", "no", "-235", "input_list" ]
     },
     "processor_terra_refined" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
         "command": [ "300", "yes", "MODIS_T", "REFINED", "no", "-235", "input_list" ]
     },
     "uploader_terra_quicklook" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateterraquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "terra", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "terra", "ops", "false" ]
     },
     "uploader_terra_refined" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateterrarefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "terra", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "terra", "ops", "false" ]
     },
     "license_returner_terra" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateterralicense",
         "command": [ "unique_id", "prefix", "terra", "ptype" ]
     },
     "downloader_viirs_quicklook" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_viirs_refined" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
     },
     "combiner_viirs_quicklook" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
         "command": [ "300", "300", "yes", "VIIRS", "QUICKLOOK", "-235", "input_list" ]
     },
     "combiner_viirs_refined" : {
-        "cpu": "8",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
         "command": [ "300", "0", "yes", "VIIRS", "REFINED", "-235", "input_list" ]
     },
     "processor_viirs_quicklook" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
         "command": [ "300", "yes", "VIIRS", "QUICKLOOK", "no", "-235", "input_list" ]
     },
     "processor_viirs_refined" : {
-        "cpu": "8",
-        "memory": "1000",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
         "command": [ "300", "yes", "VIIRS", "REFINED", "no", "-235", "input_list" ]
     },
     "uploader_viirs_quicklook" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateviirsquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "viirs", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "viirs", "ops", "false" ]
     },
     "uploader_viirs_refined" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateviirsrefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "viirs", "ops" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "viirs", "ops", "false" ]
     },
     "license_returner_viirs" : {
         "cpu": "1",
-        "memory": "256",
+        "memory": "2048",
         "share_identifier": "generateviirslicense",
         "command": [ "unique_id", "prefix", "viirs", "ptype" ]
     },
@@ -217,20 +217,20 @@
         "command": [ "unique_id", "prefix", "jpss1", "ptype" ]
     },
     "downloader_aqua_unmatched" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateaquaunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_A", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_terra_unmatched" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateterraunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "MODIS_T", "/data/output", "2000", "1", "no", "yes"]
     },
     "downloader_viirs_unmatched" : {
-        "cpu": "5",
-        "memory": "500",
+        "cpu": "1",
+        "memory": "2048",
         "share_identifier": "generateviirsunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
     },

--- a/terraform/job_config.json
+++ b/terraform/job_config.json
@@ -39,13 +39,13 @@
         "cpu": "1",
         "memory": "2048",
         "share_identifier": "generateaquaquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "aqua", "ops", "false" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "aqua", "ops" ]
     },
     "uploader_aqua_refined" : {
         "cpu": "1",
         "memory": "2048",
         "share_identifier": "generateaquarefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "aqua", "ops", "false" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "aqua", "ops" ]
     },
     "license_returner_aqua" : {
         "cpu": "1",
@@ -94,13 +94,13 @@
         "cpu": "1",
         "memory": "2048",
         "share_identifier": "generateterraquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "terra", "ops", "false" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "terra", "ops" ]
     },
     "uploader_terra_refined" : {
         "cpu": "1",
         "memory": "2048",
         "share_identifier": "generateterrarefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "terra", "ops", "false" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "terra", "ops" ]
     },
     "license_returner_terra" : {
         "cpu": "1",
@@ -148,13 +148,13 @@
         "cpu": "1",
         "memory": "2048",
         "share_identifier": "generateviirsquicklook",
-        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "viirs", "ops", "false" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "viirs", "ops" ]
     },
     "uploader_viirs_refined" : {
         "cpu": "1",
         "memory": "2048",
         "share_identifier": "generateviirsrefined",
-        "command": [ "prefix", "-235", "/data", "input_list", "refined", "viirs", "ops", "false" ]
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "viirs", "ops" ]
     },
     "license_returner_viirs" : {
         "cpu": "1",

--- a/terraform/job_config.json
+++ b/terraform/job_config.json
@@ -162,6 +162,60 @@
         "share_identifier": "generateviirslicense",
         "command": [ "unique_id", "prefix", "viirs", "ptype" ]
     },
+    "downloader_jpss1_quicklook" : {
+        "cpu": "5",
+        "memory": "500",
+        "share_identifier": "generatejpss1quicklook",
+        "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "JPSS1", "/data/output", "2000", "1", "no", "yes"]
+    },
+    "downloader_jpss1_refined" : {
+        "cpu": "5",
+        "memory": "500",
+        "share_identifier": "generatejpss1refined",
+        "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "JPSS1", "/data/output", "2000", "1", "no", "yes"]
+    },
+    "combiner_jpss1_quicklook" : {
+        "cpu": "8",
+        "memory": "500",
+        "share_identifier": "generatejpss1quicklook",
+        "command": [ "300", "300", "yes", "JPSS1", "QUICKLOOK", "-235", "input_list" ]
+    },
+    "combiner_jpss1_refined" : {
+        "cpu": "8",
+        "memory": "500",
+        "share_identifier": "generatejpss1refined",
+        "command": [ "300", "0", "yes", "JPSS1", "REFINED", "-235", "input_list" ]
+    },
+    "processor_jpss1_quicklook" : {
+        "cpu": "8",
+        "memory": "1000",
+        "share_identifier": "generatejpss1quicklook",
+        "command": [ "300", "yes", "JPSS1", "QUICKLOOK", "no", "-235", "input_list" ]
+    },
+    "processor_jpss1_refined" : {
+        "cpu": "8",
+        "memory": "1000",
+        "share_identifier": "generatejpss1refined",
+        "command": [ "300", "yes", "JPSS1", "REFINED", "no", "-235", "input_list" ]
+    },
+    "uploader_jpss1_quicklook" : {
+        "cpu": "1",
+        "memory": "256",
+        "share_identifier": "generatejpss1quicklook",
+        "command": [ "prefix", "-235", "/data", "input_list", "quicklook", "jpss1", "ops" ]
+    },
+    "uploader_jpss1_refined" : {
+        "cpu": "1",
+        "memory": "256",
+        "share_identifier": "generatejpss1refined",
+        "command": [ "prefix", "-235", "/data", "input_list", "refined", "jpss1", "ops" ]
+    },
+    "license_returner_jpss1" : {
+        "cpu": "1",
+        "memory": "256",
+        "share_identifier": "generatejpss1license",
+        "command": [ "unique_id", "prefix", "jpss1", "ptype" ]
+    },
     "downloader_aqua_unmatched" : {
         "cpu": "5",
         "memory": "500",
@@ -179,5 +233,11 @@
         "memory": "500",
         "share_identifier": "generateviirsunmatched",
         "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "VIIRS", "/data/output", "2000", "1", "no", "yes"]
+    },
+    "downloader_jpss1_unmatched" : {
+        "cpu": "5",
+        "memory": "500",
+        "share_identifier": "generatejpss1unmatched",
+        "command": ["/data/lists", "input_list", "-235", "L2", "SPACE", "JPSS1", "/data/output", "2000", "1", "no", "yes"]
     }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ data "aws_kms_key" "aws_s3" {
 }
 
 data "aws_s3_bucket" "s3_download_lists" {
-  bucket = "${var.prefix}"
+  bucket = var.prefix
 }
 
 data "aws_security_groups" "vpc_default_sg" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,6 +71,10 @@ data "aws_sqs_queue" "pending_jobs_viirs" {
   name = "${var.prefix}-pending-jobs-viirs.fifo"
 }
 
+data "aws_sqs_queue" "pending_jobs_jpss1" {
+  name = "${var.prefix}-pending-jobs-jpss1.fifo"
+}
+
 data "aws_subnet" "private_application_subnet" {
   for_each = toset(data.aws_subnets.private_application_subnets.ids)
   id       = each.value

--- a/terraform/partition_submit-lambda.tf
+++ b/terraform/partition_submit-lambda.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "aws_lambda_partition_submit" {
   role          = aws_iam_role.aws_lambda_execution_role.arn
   package_type  = "Image"
   memory_size   = 2048
-  timeout       = 600
+  timeout       = 900
   ephemeral_storage {
     size = 1024
   }

--- a/terraform/partition_submit-lambda.tf
+++ b/terraform/partition_submit-lambda.tf
@@ -171,7 +171,8 @@ resource "aws_iam_policy" "aws_lambda_execution_policy" {
         "Resource" : [
           "${data.aws_sqs_queue.pending_jobs_aqua.arn}",
           "${data.aws_sqs_queue.pending_jobs_terra.arn}",
-          "${data.aws_sqs_queue.pending_jobs_viirs.arn}"
+          "${data.aws_sqs_queue.pending_jobs_viirs.arn}",
+          "${data.aws_sqs_queue.pending_jobs_jpss1.arn}"
         ]
       },
       {

--- a/terraform/partition_submit-lambda.tf
+++ b/terraform/partition_submit-lambda.tf
@@ -19,12 +19,18 @@ resource "aws_lambda_function" "aws_lambda_partition_submit" {
   }
 }
 
+resource "aws_lambda_function_event_invoke_config" "partition_submit_lambda_config" {
+  function_name          = aws_lambda_function.aws_lambda_partition_submit.function_name
+  maximum_retry_attempts = 0
+}
+
 # Upload job configuration file to S3 bucket
 resource "aws_s3_object" "aws_s3_bucket_job_configuration" {
   bucket                 = data.aws_s3_bucket.s3_download_lists.id
   key                    = "config/job_config.json"
   server_side_encryption = "aws:kms"
   source                 = "job_config.json"
+  source_hash            = filemd5("job_config.json")
 }
 
 # Lambda resource-based policy

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "app_version" {
   type        = string
   description = "The application version number"
-  default     = "0.1.3"
+  default     = "0.1.7"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## [0.1.7]

### Description

We are migrating the managed EC2 AWS Batch Compute Environments to Fargate to prevent the need for AMI updates and to hopefully resolve the issue we are seeing with the ECS agent on EC2 instances.

Issues:

- https://github.com/podaac/generate/issues/25
- https://jira.jpl.nasa.gov/browse/PODAAC-6941

Documentation on issue:

- https://wiki.jpl.nasa.gov/pages/viewpage.action?pageId=826914206#GenerateCloudFailures&Recovery-2025-07-05-2025-07-07P&Sfailures


### Overview of work done

- Generate: Adds Fargate compute resources for batch jobs
- Generate: Removes lifeycle 'create_before_destroy' for EC2 compute resources since this policy was preventing terraform from applying the changes
- P&S: Added source hash in terraform file so it can detect changes to the job config json file
- P&S: Set retires to 0 so it only runs once
- Downloader, Combiner, Processor, Uploader, License Returner: Updated job definition/resources for Fargate instead of EC2
- Error Handler: Update EventBridge rule to ignore P&S failures.


### Overview of verification done

- Tested in SIT on three OBPG L2 granules for MODIS Aqua to produce two L2P granules

### Overview of integration done

- Tested in UAT on 7/16/2025 - 7/17/2025 time range
- Analysis of results is located here: https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+UAT+Test+v0.1.7#GenerateCloudUATTestv0.1.7-RESULTS

### Test Summary

UAT JOB METRICS:

- Total Cost: ~$157.26
- Average Execution Time: 9.65 minutes
- Average Number of Granules: 33

OPS JOB METRICS:

- Total Cost: ~$237.41 (May include other services)
- Average Execution Time: 8.8 minutes
- Average Number of Granules: 37

NOTES:

- The main difference we saw between UAT and OPS is OPS is operating in a degraded state which requires occasional manual intervention. UAT seems to have produce the usual amount of files without errors and therefore producing more granules that OPS. 
- We did see a difference in the number and average execution time of granules between UAT and OPS. This could be due to the Fargate platform which has typically had slightly longer execution times than EC2. Despite this, it seems that Generate will execute hourly on Fargate and still produce the same number of granules.